### PR TITLE
Updating to 7.3

### DIFF
--- a/ConsistencyManager/ConsistencyManager.swift
+++ b/ConsistencyManager/ConsistencyManager.swift
@@ -367,7 +367,7 @@ public class ConsistencyManager {
         let garbageCollectionInterval = self.garbageCollectionInterval
         // If garbageCollectionInterval is 0, this means it's disabled.
         if garbageCollectionInterval > 0 {
-            // Weak here is necessay, otherwise, we'd have a retain cycle.
+            // Weak here is necessary, otherwise, we'd have a retain cycle.
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(UInt64(garbageCollectionInterval) * NSEC_PER_SEC)), dispatchQueue) { [weak self] in
                 self?.cleanMemory()
                 dispatch_async(dispatch_get_main_queue()) {

--- a/ConsistencyManager/ConsistencyManager.swift
+++ b/ConsistencyManager/ConsistencyManager.swift
@@ -656,7 +656,7 @@ public class ConsistencyManager {
 
         override init() {
             super.init()
-            NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidReceiveMemoryWarning:", name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
+            NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(UIApplicationDelegate.applicationDidReceiveMemoryWarning(_:)), name: UIApplicationDidReceiveMemoryWarningNotification, object: nil)
         }
 
         deinit {

--- a/ConsistencyManager/ConsistencyManager.swift
+++ b/ConsistencyManager/ConsistencyManager.swift
@@ -57,6 +57,11 @@ public class ConsistencyManager {
      Periodically, the consistency manager cleans up after itself.
      This is a relatively quick process, and since the memory footprint of the library in general is small, it's not an important thing to worry about.
      Default is 5 mins. It will also clean up automatically on any memory warnings.
+
+     If you set this to zero, then garbage collection is considered disabled.
+     The ConsistencyManager will still attempt to clean up memory if the application receives a memory warning.
+
+     This variable is not thread-safe. You should only access this on the main thread.
      */
     public var garbageCollectionInterval: NSTimeInterval = 300
 
@@ -96,7 +101,10 @@ public class ConsistencyManager {
      */
     public init() {
         memoryWarningListener.delegate = self
-        startGarbageCollection()
+        // Doing this in the next tick to give the caller a chance to set garbageCollectionInterval
+        dispatch_async(dispatch_get_main_queue()) { 
+            self.startGarbageCollection()
+        }
     }
 
     // MARK: - Public Functions
@@ -355,10 +363,17 @@ public class ConsistencyManager {
      It is called once on initialization to start the process. This will cause a cleanMemory call, but that's ok since it will be basically a no-op.
      */
     private func startGarbageCollection() {
-        // Weak here is necessay, otherwise, we'd have a retain cycle.
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(UInt64(garbageCollectionInterval) * NSEC_PER_SEC)), dispatchQueue) { [weak self] in
-            self?.cleanMemory()
-            self?.startGarbageCollection()
+        // Saving a local variable so we only access this on the main thread
+        let garbageCollectionInterval = self.garbageCollectionInterval
+        // If garbageCollectionInterval is 0, this means it's disabled.
+        if garbageCollectionInterval > 0 {
+            // Weak here is necessay, otherwise, we'd have a retain cycle.
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(UInt64(garbageCollectionInterval) * NSEC_PER_SEC)), dispatchQueue) { [weak self] in
+                self?.cleanMemory()
+                dispatch_async(dispatch_get_main_queue()) {
+                    self?.startGarbageCollection()
+                }
+            }
         }
     }
 

--- a/ConsistencyManagerTests/BatchListenerTest.swift
+++ b/ConsistencyManagerTests/BatchListenerTest.swift
@@ -25,7 +25,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledUpdateClosure = 0
         batchDelegate.updateClosure = { batchListener, listeners, updates, context in
-            calledUpdateClosure++
+            calledUpdateClosure += 1
             XCTAssertTrue(batchListener === batchUpdateListener)
             XCTAssertEqual(listeners.count, 1)
             XCTAssertTrue(listeners[0] === listener)
@@ -39,7 +39,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListenerUpdateClosure = 0
         listener.updateClosure = { _, updates in
-            calledListenerUpdateClosure++
+            calledListenerUpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds.count, 2)
             XCTAssertEqual(updates.deletedModelIds.count, 0)
             XCTAssertTrue(updates.changedModelIds.contains("0"))
@@ -70,7 +70,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledUpdateClosure = 0
         batchDelegate.updateClosure = { batchListener, listeners, updates, context in
-            calledUpdateClosure++
+            calledUpdateClosure += 1
             XCTAssertTrue(batchListener === batchUpdateListener)
             XCTAssertEqual(listeners.count, 1)
             XCTAssertTrue(listeners[0] === listener)
@@ -85,7 +85,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListenerUpdateClosure = 0
         listener.updateClosure = { _, updates in
-            calledListenerUpdateClosure++
+            calledListenerUpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds, ["0", "1"])
             XCTAssertEqual(updates.deletedModelIds.count, 0)
         }
@@ -118,7 +118,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledUpdateClosure = 0
         batchDelegate.updateClosure = { batchListener, listeners, updates, context in
-            calledUpdateClosure++
+            calledUpdateClosure += 1
             XCTAssertTrue(batchListener === batchUpdateListener)
             XCTAssertEqual(listeners.count, 2)
             XCTAssertTrue(listeners[0] === listener)
@@ -136,7 +136,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListenerUpdateClosure = 0
         listener.updateClosure = { _, updates in
-            calledListenerUpdateClosure++
+            calledListenerUpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds.count, 2)
             XCTAssertEqual(updates.deletedModelIds.count, 0)
             XCTAssertTrue(updates.changedModelIds.contains("0"))
@@ -148,7 +148,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListener2UpdateClosure = 0
         listener2.updateClosure = { _, updates in
-            calledListener2UpdateClosure++
+            calledListener2UpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds.count, 2)
             XCTAssertEqual(updates.deletedModelIds.count, 0)
             XCTAssertTrue(updates.changedModelIds.contains("2"))
@@ -178,7 +178,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledUpdateClosure = 0
         batchDelegate.updateClosure = { batchListener, listeners, updates, context in
-            calledUpdateClosure++
+            calledUpdateClosure += 1
             XCTAssertTrue(batchListener === batchUpdateListener)
             XCTAssertEqual(listeners.count, 2)
             XCTAssertTrue(listeners[0] === listener)
@@ -197,7 +197,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListenerUpdateClosure = 0
         listener.updateClosure = { _, updates in
-            calledListenerUpdateClosure++
+            calledListenerUpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds.count, 1)
             XCTAssertTrue(updates.changedModelIds.contains("0"))
             XCTAssertEqual(updates.deletedModelIds.count, 2)
@@ -210,7 +210,7 @@ class BatchListenerTest: ConsistencyManagerTestCase {
 
         var calledListener2UpdateClosure = 0
         listener2.updateClosure = { _, updates in
-            calledListener2UpdateClosure++
+            calledListener2UpdateClosure += 1
             XCTAssertEqual(updates.changedModelIds.count, 1)
             XCTAssertTrue(updates.changedModelIds.contains("2"))
             XCTAssertEqual(updates.deletedModelIds.count, 2)

--- a/ConsistencyManagerTests/BatchUpdateTests.swift
+++ b/ConsistencyManagerTests/BatchUpdateTests.swift
@@ -24,7 +24,7 @@ class BatchUpdateTests: ConsistencyManagerTestCase {
 
         var numberOfUpdates = 0
         listener.updateClosure = { _ in
-            numberOfUpdates++
+            numberOfUpdates += 1
         }
 
         let updateModel1 = TestModel(id: "2", data: -2, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))

--- a/ConsistencyManagerTests/DataStructureTests/WeakArrayTests.swift
+++ b/ConsistencyManagerTests/DataStructureTests/WeakArrayTests.swift
@@ -311,7 +311,7 @@ class WeakArrayTests: ConsistencyManagerTestCase {
             var iterations = 0
             for element in weakArray {
                 XCTAssertNil(element)
-                iterations++
+                iterations += 1
             }
             // Should have iterated over every value
             XCTAssertEqual(iterations, count)

--- a/ConsistencyManagerTests/DataStructureTests/WeakListenerArrayTests.swift
+++ b/ConsistencyManagerTests/DataStructureTests/WeakListenerArrayTests.swift
@@ -290,7 +290,7 @@ class WeakListenerArrayTests: ConsistencyManagerTestCase {
             var iterations = 0
             for element in weakArray {
                 XCTAssertNil(element)
-                iterations++
+                iterations += 1
             }
             // Should have iterated over every value
             XCTAssertEqual(iterations, count)

--- a/ConsistencyManagerTests/HelperClasses/TestModelGenerator.swift
+++ b/ConsistencyManagerTests/HelperClasses/TestModelGenerator.swift
@@ -80,7 +80,7 @@ class TestModelGenerator {
                 currentNode.children.append(newChild)
                 // Also, let's add it to the queue
                 nodeQueue.append(newChild)
-                remainingNodes--
+                remainingNodes -= 1
             }
         }
 

--- a/ConsistencyManagerTests/PauseListenerTests.swift
+++ b/ConsistencyManagerTests/PauseListenerTests.swift
@@ -47,7 +47,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdates = 0
         var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         listener.updateClosure = { (_, updates) in
-            numberOfUpdates++
+            numberOfUpdates += 1
             modelUpdates = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -131,11 +131,11 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdates2 = 0
         var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         activeListener.updateClosure = { (_, updates) in
-            numberOfUpdates1++
+            numberOfUpdates1 += 1
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
         pausedListener.updateClosure = { (_, updates) in
-            numberOfUpdates2++
+            numberOfUpdates2 += 1
             modelUpdatesPausedListener = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -218,7 +218,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdates = 0
         var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         listener.updateClosure = { (_, updates) in
-            numberOfUpdates++
+            numberOfUpdates += 1
             modelUpdates = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -256,7 +256,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdates = 0
         var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         listener.updateClosure = { (_, updates) in
-            numberOfUpdates++
+            numberOfUpdates += 1
             modelUpdates = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -306,7 +306,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdatesToPausedListener = 0
         var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         pausedListener.updateClosure = { (_, updates) in
-            numberOfUpdatesToPausedListener++
+            numberOfUpdatesToPausedListener += 1
             modelUpdatesPausedListener = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -319,7 +319,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
         var numberOfUpdatesToActiveListener = 0
         var modelUpdatesActiveListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
         activeListener.updateClosure = { (_, updates) in
-            numberOfUpdatesToActiveListener++
+            numberOfUpdatesToActiveListener += 1
             modelUpdatesActiveListener = updates
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -489,14 +489,14 @@ class PauseListenerTests: ConsistencyManagerTestCase {
             calledPausedListenerUpdateClosure = true
             XCTAssertEqual(updates.changedModelIds.count, 0)
             XCTAssertEqual(updates.deletedModelIds, ["0"])
-            numberOfUpdatesforPausedListener++
+            numberOfUpdatesforPausedListener += 1
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
         var calledActiveListenerUpdateClosure = false
         var numberOfUpdatesForActiveListener = 0
         activeListener.updateClosure = { model, updates in
             calledActiveListenerUpdateClosure = true
-            numberOfUpdatesForActiveListener++
+            numberOfUpdatesForActiveListener += 1
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
 
@@ -540,7 +540,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
 
         var numberOfUpdates = 0
         listener.updateClosure = { (_, updates) in
-            numberOfUpdates++
+            numberOfUpdates += 1
             XCTAssertEqual(updates.deletedModelIds, ["0"])
             XCTAssertTrue(NSThread.currentThread().isMainThread)
         }
@@ -573,7 +573,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
 
         var numberOfUpdates = 0
         listener.updateClosure = { (_, updates) in
-            numberOfUpdates++
+            numberOfUpdates += 1
             XCTAssertEqual(updates.deletedModelIds, ["0", "1"])
             XCTAssertEqual(updates.changedModelIds, [])
             XCTAssertTrue(NSThread.currentThread().isMainThread)
@@ -688,7 +688,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
 
         var updates = 0
         batchDelegate.updateClosure = { _, _, _, _ in
-            updates++
+            updates += 1
         }
 
         updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "context")
@@ -716,7 +716,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
 
         var updates = 0
         batchDelegate.updateClosure = { _, _, _, _ in
-            updates++
+            updates += 1
         }
 
         updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "context")
@@ -745,12 +745,12 @@ class PauseListenerTests: ConsistencyManagerTestCase {
 
         var updatesToBatch = 0
         batchDelegate.updateClosure = { _, _, _, _ in
-            updatesToBatch++
+            updatesToBatch += 1
         }
 
         var updatesToIndividual = 0
         individualListener.updateClosure = { _, _ in
-            updatesToIndividual++
+            updatesToIndividual += 1
         }
 
         let updateModel = TestModel(id: "0", data: 4, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))

--- a/ConsistencyManagerTests/RaceConditionsTests.swift
+++ b/ConsistencyManagerTests/RaceConditionsTests.swift
@@ -41,7 +41,7 @@ class RaceConditionsTests: ConsistencyManagerTestCase {
             // The reason this is only necessary the first time is that changing the model in this method is an antipattern. This just simulates the bug. The second time it's called, it's called on the same thread as the update happenes so there can be no race condition there.
             if updates == 0 {
                 listener.model = newModel
-                updates++
+                updates += 1
             }
         }
 
@@ -74,7 +74,7 @@ class RaceConditionsTests: ConsistencyManagerTestCase {
         // This actually gets called 4 times
         // It gets called twice in a row first, then two more times again. These should each be grouped on their own thread.
         let modelRequested = {
-            numberOfCurrentModelRequests++
+            numberOfCurrentModelRequests += 1
 
             if numberOfCurrentModelRequests > 2 {
                 dispatch_async(dispatch_get_main_queue()) {
@@ -91,7 +91,7 @@ class RaceConditionsTests: ConsistencyManagerTestCase {
 
         var updates = 0
         let modelUpdated: (ConsistencyManagerModel?, ModelUpdates) -> Void = { _, _ in
-            updates++
+            updates += 1
             
             // Let's dispatch and get the next main block
             // When we do this, we should get both updated

--- a/ConsistencyManagerTests/UpdateOrderingTests.swift
+++ b/ConsistencyManagerTests/UpdateOrderingTests.swift
@@ -39,11 +39,11 @@ class UpdateOrderingTests: ConsistencyManagerTestCase {
                 listener.updateClosure = { model, updates in
                     if let model = model as? TestModel {
                         if numberTimesCallbackCalled == 0 {
-                            numberTimesCallbackCalled++
+                            numberTimesCallbackCalled += 1
                             // On first update, we should have the new large model
                             XCTAssertEqual(model, newLargeModel)
                         } else if numberTimesCallbackCalled == 1 {
-                            numberTimesCallbackCalled++
+                            numberTimesCallbackCalled += 1
                             // Second time, it should have changed to our new smaller model
                             XCTAssertEqual(model, newModel)
                         } else {

--- a/ConsistencyManagerTests/UpdateTests.swift
+++ b/ConsistencyManagerTests/UpdateTests.swift
@@ -86,7 +86,7 @@ class UpdateTests: ConsistencyManagerTestCase {
         // Let's skip 2 models since then the listener won't have a subtree
         for numberOfModels in 4.stride(through: 40, by: 4) {
             for branchingFactor in 1...5 {
-                let testModel = TestModelGenerator.testModelWithTotalChildren(numberOfModels, branchingFactor: branchingFactor) { id in
+                let testModel: TestModel = TestModelGenerator.testModelWithTotalChildren(numberOfModels, branchingFactor: branchingFactor) { id in
                     // Let's make everything we're testing have an id. This will be 0, 2, 6, 10...
                     return id == 0 || (id + 2) % 4 == 0
                 }
@@ -124,7 +124,7 @@ class UpdateTests: ConsistencyManagerTestCase {
         // Let's skip 2 models since then the listener won't have a subtree
         for numberOfModels in 4.stride(through: 40, by: 4) {
             for branchingFactor in 1...5 {
-                let testModel = TestModelGenerator.testModelWithTotalChildren(numberOfModels, branchingFactor: branchingFactor) { id in
+                let testModel: TestModel = TestModelGenerator.testModelWithTotalChildren(numberOfModels, branchingFactor: branchingFactor) { id in
                     // Let's make everything we're testing have an id. This will be 0, 2, 6, 10...
                     return id == 0 || (id + 2) % 4 == 0
                 }


### PR DESCRIPTION
Updating the codebase to Xcode 7.3
- Updating selector syntax
- Replacing ++ with += 1
- Adding some types so the compiler doesn't error complaining it's too complex
