### PR TITLE
Updating all existing tests to test both projections and not projections (only updated tests that made sense)

### DIFF
--- a/ConsistencyManager.xcodeproj/project.pbxproj
+++ b/ConsistencyManager.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		6144A8341CB6DF1B00025127 /* TestRequiredModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6144A81E1CB6DF1B00025127 /* TestRequiredModel.swift */; };
 		6144A8361CB6DF1B00025127 /* ModelUpdatesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6144A8201CB6DF1B00025127 /* ModelUpdatesTests.swift */; };
 		614661E61A0293B3001C9B50 /* ConsistencyManager.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61DBAA5419FFF64100A23A60 /* ConsistencyManager.framework */; };
+		615B9CA91D4FFD430091F71A /* ProjectionTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B9CA81D4FFD430091F71A /* ProjectionTestModel.swift */; };
 		F29D8FC71CC52EBB005DBB71 /* PauseListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29D8FC61CC52EBB005DBB71 /* PauseListenerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -93,6 +94,7 @@
 		6144A81E1CB6DF1B00025127 /* TestRequiredModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestRequiredModel.swift; sourceTree = "<group>"; };
 		6144A81F1CB6DF1B00025127 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6144A8201CB6DF1B00025127 /* ModelUpdatesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModelUpdatesTests.swift; sourceTree = "<group>"; };
+		615B9CA81D4FFD430091F71A /* ProjectionTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionTestModel.swift; sourceTree = "<group>"; };
 		61DBAA5419FFF64100A23A60 /* ConsistencyManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ConsistencyManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61DBAA5F19FFF64100A23A60 /* ConsistencyManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConsistencyManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F29D8FC61CC52EBB005DBB71 /* PauseListenerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PauseListenerTests.swift; sourceTree = "<group>"; };
@@ -202,8 +204,9 @@
 				6144A81A1CB6DF1B00025127 /* ConsistencyManagerTestCase.swift */,
 				6144A81B1CB6DF1B00025127 /* TestListener.swift */,
 				6144A81C1CB6DF1B00025127 /* TestModel.swift */,
-				6144A81D1CB6DF1B00025127 /* TestModelGenerator.swift */,
+				615B9CA81D4FFD430091F71A /* ProjectionTestModel.swift */,
 				6144A81E1CB6DF1B00025127 /* TestRequiredModel.swift */,
+				6144A81D1CB6DF1B00025127 /* TestModelGenerator.swift */,
 			);
 			path = HelperClasses;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 				6144A8261CB6DF1B00025127 /* ListenerTests.swift in Sources */,
 				6144A8301CB6DF1B00025127 /* ConsistencyManagerTestCase.swift in Sources */,
 				6144A82F1CB6DF1B00025127 /* WeakArrayTests.swift in Sources */,
+				615B9CA91D4FFD430091F71A /* ProjectionTestModel.swift in Sources */,
 				6144A82D1CB6DF1B00025127 /* UpdateOrderingTests.swift in Sources */,
 				6144A8211CB6DF1B00025127 /* BatchListenerTest.swift in Sources */,
 				F29D8FC71CC52EBB005DBB71 /* PauseListenerTests.swift in Sources */,

--- a/ConsistencyManagerTests/ContextTests.swift
+++ b/ConsistencyManagerTests/ContextTests.swift
@@ -13,26 +13,28 @@ import ConsistencyManager
 class ContextTests: ConsistencyManagerTestCase {
 
     func testContextPassedThrough() {
-        let testModel = TestModelGenerator.testModelWithTotalChildren(20, branchingFactor: 3) { id in
-            return true
+        for testProjections in [true, false] {
+            let testModel = TestModelGenerator.consistencyManagerModelWithTotalChildren(20, branchingFactor: 3, projectionModel: testProjections) { id in
+                return true
+            }
+
+            let consistencyManager = ConsistencyManager()
+            let listener = TestListener(model: testModel)
+
+            addListener(listener, toConsistencyManager: consistencyManager)
+
+            // Pick a random child
+            let updateModel = TestModel(id: "2", data: -1, children: [], requiredModel: TestRequiredModel(id: nil, data: -1))
+
+            var contextClosureCalled = false
+            listener.contextClosure = { context in
+                contextClosureCalled = true
+                XCTAssertEqual(context as? Int, 4)
+            }
+
+            updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: 4)
+            
+            XCTAssertTrue(contextClosureCalled)
         }
-
-        let consistencyManager = ConsistencyManager()
-        let listener = TestListener(model: testModel)
-
-        addListener(listener, toConsistencyManager: consistencyManager)
-
-        // Pick a random child
-        let updateModel = TestModel(id: "2", data: -1, children: [], requiredModel: TestRequiredModel(id: nil, data: -1))
-
-        var contextClosureCalled = false
-        listener.contextClosure = { context in
-            contextClosureCalled = true
-            XCTAssertEqual(context as? Int, 4)
-        }
-
-        updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: 4)
-
-        XCTAssertTrue(contextClosureCalled)
     }
 }

--- a/ConsistencyManagerTests/DeleteTests.swift
+++ b/ConsistencyManagerTests/DeleteTests.swift
@@ -26,6 +26,21 @@ class DeleteTests: ConsistencyManagerTestCase {
         XCTAssertTrue(listener.model == nil)
     }
 
+    func testDeleteWholeModelProjection() {
+        let model = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
+
+        let consistencyManager = ConsistencyManager()
+        let listener = TestListener(model: model)
+
+        addListener(listener, toConsistencyManager: consistencyManager)
+
+        let modelToDelete = ProjectionTestModel(id: "0", data: nil, otherData: nil, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
+
+        deleteModel(modelToDelete, consistencyManager: consistencyManager)
+
+        XCTAssertTrue(listener.model == nil)
+    }
+
     func testDeleteOptionalChild() {
         let requiredModel = TestRequiredModel(id: "100", data: 0)
         let child = TestModel(id: "1", data: nil, children: [], requiredModel: requiredModel)
@@ -37,6 +52,29 @@ class DeleteTests: ConsistencyManagerTestCase {
         addListener(listener, toConsistencyManager: consistencyManager)
 
         deleteModel(child, consistencyManager: consistencyManager)
+
+        // The child model should have disappeared
+        let expected = TestModel(id: "0", data: nil, children: [], requiredModel: requiredModel)
+        if let model = listener.model as? TestModel {
+            XCTAssertEqual(model, expected)
+        } else {
+            XCTFail()
+        }
+    }
+
+    func testDeleteOptionalChildProjection() {
+        let requiredModel = TestRequiredModel(id: "100", data: 0)
+        let child = TestModel(id: "1", data: nil, children: [], requiredModel: requiredModel)
+        let model = TestModel(id: "0", data: nil, children: [child], requiredModel: requiredModel)
+
+        let consistencyManager = ConsistencyManager()
+        let listener = TestListener(model: model)
+
+        addListener(listener, toConsistencyManager: consistencyManager)
+
+        let modelToDelete = ProjectionTestModel(id: "1", data: nil, otherData: nil, children: [], requiredModel: requiredModel)
+
+        deleteModel(modelToDelete, consistencyManager: consistencyManager)
 
         // The child model should have disappeared
         let expected = TestModel(id: "0", data: nil, children: [], requiredModel: requiredModel)

--- a/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
+++ b/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
@@ -38,6 +38,22 @@ class ConsistencyManagerTestCase: XCTestCase {
         waitOnMainThread()
     }
 
+    /**
+     This helper function is useful for testing projections.
+     We want to validate the fields of our model, but aren't sure if it's a TestModel or ProjectionTestModel.
+     This converts it to a TestModel and allows us to test the fields of the model.
+     */
+    func testModelFromListenerModel(model: ConsistencyManagerModel?) -> TestModel? {
+        if let model = model as? TestModel {
+            return model
+        } else if let model = model as? ProjectionTestModel {
+            return TestModel.testModelFromProjection(model)
+        } else {
+            XCTFail("Cannot convert listener model to test model.")
+            return nil
+        }
+    }
+
     func deleteModel(model: ConsistencyManagerModel, consistencyManager: ConsistencyManager, context: Any? = nil) {
         consistencyManager.deleteModel(model, context: context)
 
@@ -82,7 +98,7 @@ class ConsistencyManagerTestCase: XCTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectationsWithTimeout(1) { error in
+        waitForExpectationsWithTimeout(10) { error in
             XCTAssertNil(error)
         }
     }

--- a/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
+++ b/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
@@ -12,17 +12,21 @@ import ConsistencyManager
 
 
 /**
-This model is intended for unit testing the consistency manager. It simply declares some child objects and some data.
-*/
-final class TestModel: ConsistencyManagerModel, Equatable {
+ This model is intended for unit testing the consistency manager. It simply declares some child objects and some data.
+ It is similar to TestModel but declares an extra field.
+ Therefore, it also implements mergeModel which will merge TestModel into this model.
+ */
+final class ProjectionTestModel: ConsistencyManagerModel, Equatable {
     let id: String?
     let data: Int?
-    let children: [TestModel]
+    let otherData: Int?
+    let children: [ProjectionTestModel]
     let requiredModel: TestRequiredModel
 
-    init(id: String?, data: Int?, children: [TestModel], requiredModel: TestRequiredModel) {
+    init(id: String?, data: Int?, otherData: Int?, children: [ProjectionTestModel], requiredModel: TestRequiredModel) {
         self.id = id
         self.data = data
+        self.otherData = otherData
         self.children = children
         self.requiredModel = requiredModel
     }
@@ -32,9 +36,9 @@ final class TestModel: ConsistencyManagerModel, Equatable {
     }
 
     func map(transform: ConsistencyManagerModel -> ConsistencyManagerModel?) -> ConsistencyManagerModel? {
-        var newChildren: [TestModel] = []
+        var newChildren: [ProjectionTestModel] = []
         for model in children {
-            let newModel = transform(model) as? TestModel
+            let newModel = transform(model) as? ProjectionTestModel
             if let newModel = newModel {
                 newChildren.append(newModel)
             }
@@ -42,7 +46,7 @@ final class TestModel: ConsistencyManagerModel, Equatable {
 
         let newRequiredModel = transform(requiredModel) as? TestRequiredModel
         if let newRequiredModel = newRequiredModel {
-            return TestModel(id: id, data: data, children: newChildren, requiredModel: newRequiredModel)
+            return ProjectionTestModel(id: id, data: data, otherData: otherData, children: newChildren, requiredModel: newRequiredModel)
         } else {
             return nil
         }
@@ -56,10 +60,10 @@ final class TestModel: ConsistencyManagerModel, Equatable {
     }
 
     func mergeModel(model: ConsistencyManagerModel) -> ConsistencyManagerModel {
-        if let model = model as? TestModel {
+        if let model = model as? ProjectionTestModel {
             return model
-        } else if let model = model as? ProjectionTestModel {
-            return TestModel.testModelFromProjection(model)
+        } else if let model = model as? TestModel {
+            return testModelFromProjection(model)
         } else {
             assertionFailure("Tried to merge two models which cannot be merged: \(self.dynamicType) and \(model.dynamicType)")
             // The best we can do is return self (no merging done)
@@ -67,35 +71,37 @@ final class TestModel: ConsistencyManagerModel, Equatable {
         }
     }
 
-    static func testModelFromProjection(model: ProjectionTestModel) -> TestModel {
+    private func testModelFromProjection(model: TestModel) -> ProjectionTestModel {
         let children = model.children.map { currentChild in
             return testModelFromProjection(currentChild)
         }
-        return TestModel(id: model.id, data: model.data, children: children, requiredModel: model.requiredModel)
+        // For otherData, we're going to use our current value. For everything else, we're going to use the other model's values.
+        return ProjectionTestModel(id: model.id, data: model.data, otherData: otherData, children: children, requiredModel: model.requiredModel)
     }
 }
 
 // MARK - Equatable
 
-func ==(lhs: TestModel, rhs: TestModel) -> Bool {
+func ==(lhs: ProjectionTestModel, rhs: ProjectionTestModel) -> Bool {
     return lhs.id == rhs.id
         && lhs.data == rhs.data
+        && lhs.otherData == rhs.otherData
         && lhs.children == rhs.children
         && lhs.requiredModel == rhs.requiredModel
 }
 
 // MARK - CustomStringConvertible
 
-extension TestModel: CustomStringConvertible {
+extension ProjectionTestModel: CustomStringConvertible {
     var description: String {
-        return "\(id):\(data)-\(requiredModel)-\(children)"
+        return "\(id):\(data):\(otherData)-\(requiredModel)-\(children)"
     }
 }
 
 // MARK - Helpers
 
-extension TestModel {
-    func recursiveChildWithId(id: String) -> TestModel? {
+extension ProjectionTestModel {
+    func recursiveChildWithId(id: String) -> ProjectionTestModel? {
         if let currentId = self.id {
             if currentId == id {
                 return self
@@ -107,7 +113,7 @@ extension TestModel {
                 return foundModel
             }
         }
-        
+
         // We didn't find anything
         return nil
     }

--- a/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
+++ b/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
@@ -38,14 +38,12 @@ final class ProjectionTestModel: ConsistencyManagerModel, Equatable {
     func map(transform: ConsistencyManagerModel -> ConsistencyManagerModel?) -> ConsistencyManagerModel? {
         var newChildren: [ProjectionTestModel] = []
         for model in children {
-            let newModel = transform(model) as? ProjectionTestModel
-            if let newModel = newModel {
+            if let newModel = transform(model) as? ProjectionTestModel {
                 newChildren.append(newModel)
             }
         }
 
-        let newRequiredModel = transform(requiredModel) as? TestRequiredModel
-        if let newRequiredModel = newRequiredModel {
+        if let newRequiredModel = transform(requiredModel) as? TestRequiredModel {
             return ProjectionTestModel(id: id, data: data, otherData: otherData, children: newChildren, requiredModel: newRequiredModel)
         } else {
             return nil

--- a/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
+++ b/ConsistencyManagerTests/HelperClasses/ProjectionTestModel.swift
@@ -70,11 +70,11 @@ final class ProjectionTestModel: ConsistencyManagerModel, Equatable {
     }
 
     private func testModelFromProjection(model: TestModel) -> ProjectionTestModel {
-        let children = model.children.map { currentChild in
+        let newChildren = model.children.map { currentChild in
             return testModelFromProjection(currentChild)
         }
         // For otherData, we're going to use our current value. For everything else, we're going to use the other model's values.
-        return ProjectionTestModel(id: model.id, data: model.data, otherData: otherData, children: children, requiredModel: model.requiredModel)
+        return ProjectionTestModel(id: model.id, data: model.data, otherData: otherData, children: newChildren, requiredModel: model.requiredModel)
     }
 }
 

--- a/ConsistencyManagerTests/HelperClasses/TestModel.swift
+++ b/ConsistencyManagerTests/HelperClasses/TestModel.swift
@@ -34,14 +34,12 @@ final class TestModel: ConsistencyManagerModel, Equatable {
     func map(transform: ConsistencyManagerModel -> ConsistencyManagerModel?) -> ConsistencyManagerModel? {
         var newChildren: [TestModel] = []
         for model in children {
-            let newModel = transform(model) as? TestModel
-            if let newModel = newModel {
+            if let newModel = transform(model) as? TestModel {
                 newChildren.append(newModel)
             }
         }
 
-        let newRequiredModel = transform(requiredModel) as? TestRequiredModel
-        if let newRequiredModel = newRequiredModel {
+        if let newRequiredModel = transform(requiredModel) as? TestRequiredModel {
             return TestModel(id: id, data: data, children: newChildren, requiredModel: newRequiredModel)
         } else {
             return nil

--- a/ConsistencyManagerTests/PauseListenerTests.swift
+++ b/ConsistencyManagerTests/PauseListenerTests.swift
@@ -18,9 +18,9 @@ class PauseListenerTests: ConsistencyManagerTestCase {
     /**
      This provides some reusable code for generating a test model with many children.
      */
-    func setUpListeners(quantity: Int, testProjections: Bool) -> ([TestListener], ConsistencyManager) {
+    func setUpListeners(quantity: Int, projectionModel: Bool) -> ([TestListener], ConsistencyManager) {
         // We generate models with varying lists of children for more thorough testing.
-        let testModel = TestModelGenerator.consistencyManagerModelWithTotalChildren(10, branchingFactor: 3, projectionModel: testProjections) { id in
+        let testModel = TestModelGenerator.consistencyManagerModelWithTotalChildren(10, branchingFactor: 3, projectionModel: projectionModel) { id in
             return true
         }
 
@@ -42,7 +42,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      */
     func testUpdatesBetweenPausingAndResuming() {
         for testProjections in [true, false] {
-            let (listeners, consistencyManager) = setUpListeners(1, testProjections: testProjections)
+            let (listeners, consistencyManager) = setUpListeners(1, projectionModel: testProjections)
             let listener = listeners[0]
 
             var numberOfUpdates = 0
@@ -126,7 +126,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      */
     func testMultipleListenersWithPausingAndResuming() {
         for testProjections in [true, false] {
-            var (listeners, consistencyManager) = setUpListeners(2, testProjections: testProjections)
+            var (listeners, consistencyManager) = setUpListeners(2, projectionModel: testProjections)
             let activeListener = listeners[0]
             let pausedListener = listeners[1]
 
@@ -217,7 +217,7 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      */
     func testNoChangesWhilePaused() {
         for testProjections in [true, false] {
-            let (listeners, consistencyManager) = setUpListeners(1, testProjections: testProjections)
+            let (listeners, consistencyManager) = setUpListeners(1, projectionModel: testProjections)
             let listener = listeners[0]
 
             var numberOfUpdates = 0

--- a/ConsistencyManagerTests/PauseListenerTests.swift
+++ b/ConsistencyManagerTests/PauseListenerTests.swift
@@ -415,9 +415,9 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      We confirm at the end that only the persistent deletes and changes stay in the changelist when the listener
      resumes listening.
 
-     0
-     / | \
-     2  4  1r
+         0
+       / | \
+      2  4  1r
      /
      3r
 

--- a/ConsistencyManagerTests/PauseListenerTests.swift
+++ b/ConsistencyManagerTests/PauseListenerTests.swift
@@ -434,9 +434,9 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      Resume
      Result should be: Deleted [], and Updated [0,2]
 
-     0
-     / | \
-     2' 4  1r
+         0
+       / | \
+      2' 4  1r
      /
      3r
      */

--- a/ConsistencyManagerTests/PauseListenerTests.swift
+++ b/ConsistencyManagerTests/PauseListenerTests.swift
@@ -18,9 +18,9 @@ class PauseListenerTests: ConsistencyManagerTestCase {
     /**
      This provides some reusable code for generating a test model with many children.
      */
-    func setUpListeners(quantity: Int) -> ([TestListener], ConsistencyManager) {
+    func setUpListeners(quantity: Int, testProjections: Bool) -> ([TestListener], ConsistencyManager) {
         // We generate models with varying lists of children for more thorough testing.
-        let testModel = TestModelGenerator.testModelWithTotalChildren(10, branchingFactor: 3) { id in
+        let testModel = TestModelGenerator.consistencyManagerModelWithTotalChildren(10, branchingFactor: 3, projectionModel: testProjections) { id in
             return true
         }
 
@@ -41,79 +41,81 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      it resumes listening.
      */
     func testUpdatesBetweenPausingAndResuming() {
-        let (listeners, consistencyManager) = setUpListeners(1)
-        let listener = listeners[0]
+        for testProjections in [true, false] {
+            let (listeners, consistencyManager) = setUpListeners(1, testProjections: testProjections)
+            let listener = listeners[0]
 
-        var numberOfUpdates = 0
-        var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
-        listener.updateClosure = { (_, updates) in
-            numberOfUpdates += 1
-            modelUpdates = updates
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
-        }
-        var contextString: String?
-        listener.contextClosure = { context in
-            if let context = context as? String {
-                contextString = context
+            var numberOfUpdates = 0
+            var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
+            listener.updateClosure = { (_, updates) in
+                numberOfUpdates += 1
+                modelUpdates = updates
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
             }
+            var contextString: String?
+            listener.contextClosure = { context in
+                if let context = context as? String {
+                    contextString = context
+                }
+            }
+
+            // Current models before the update
+            var testModel = testModelFromListenerModel(listener.model)!
+            XCTAssertEqual(testModel.children[0].data, 2)
+            XCTAssertEqual(testModel.children[1].data, 4)
+            XCTAssertEqual(modelUpdates.changedModelIds, [])
+            XCTAssertEqual(modelUpdates.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates, 0)
+
+            XCTAssertFalse(consistencyManager.isPaused(listener))
+            pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(listener))
+            // Pausing again shouldn't affect anything. We should still only get one callback.
+            pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(listener))
+            // Similarly, adding the listener again shouldn't affect anything, as this does not resume the listening of the listener.
+            addListener(listener, toConsistencyManager: consistencyManager)
+
+            testModel = testModelFromListenerModel(listener.model)!
+            let updateModel1 = TestModel(id: "2", data: -2, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let updateModel2 = TestModel(id: "4", data: -4, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let batchModel = BatchUpdateModel(models: [updateModel1, updateModel2])
+            updateWithNewModel(batchModel, consistencyManager: consistencyManager, context: "change")
+
+            testModel = testModelFromListenerModel(listener.model)!
+            // Updates have happened, but we didn't listen for them.
+            XCTAssertEqual(testModel.children[0].data, 2)
+            XCTAssertEqual(testModel.children[1].data, 4)
+            XCTAssertEqual(modelUpdates.changedModelIds, [])
+            XCTAssertEqual(modelUpdates.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates, 0)
+
+            let updateModel3 = TestModel(id: "2", data: -5, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let updateModel4 = TestModel(id: "4", data: -6, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let batchModel2 = BatchUpdateModel(models: [updateModel3, updateModel4])
+            updateWithNewModel(batchModel2, consistencyManager: consistencyManager, context: "change2")
+
+            testModel = testModelFromListenerModel(listener.model)!
+            // Updates have happened, but we didn't listen for them.
+            XCTAssertEqual(testModel.children[0].data, 2)
+            XCTAssertEqual(testModel.children[1].data, 4)
+            XCTAssertEqual(modelUpdates.changedModelIds, [])
+            XCTAssertEqual(modelUpdates.deletedModelIds, [])
+            XCTAssertNil(contextString)
+            XCTAssertEqual(numberOfUpdates, 0)
+
+            // Resume listening for changes, and get all previous changes.
+            resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
+
+            // Both models were updated, and now we have listened to those updates.
+            testModel = testModelFromListenerModel(listener.model)!
+            XCTAssertEqual(testModel.children[0].data, -5)
+            XCTAssertEqual(testModel.children[1].data, -6)
+            XCTAssertEqual(modelUpdates.changedModelIds, ["0","2","4"]) // O is the root, so it's changed as well
+            XCTAssertEqual(modelUpdates.deletedModelIds, [])
+            XCTAssertEqual(contextString, "change2") // Only the last context is received.
+            XCTAssertEqual(numberOfUpdates, 1) // We only count the final batch update to the models that occurs after we resume listening.
         }
-
-        // Current models before the update
-        var testModel = listener.model as! TestModel
-        XCTAssertEqual(testModel.children[0].data, 2)
-        XCTAssertEqual(testModel.children[1].data, 4)
-        XCTAssertEqual(modelUpdates.changedModelIds, [])
-        XCTAssertEqual(modelUpdates.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates, 0)
-
-        XCTAssertFalse(consistencyManager.isPaused(listener))
-        pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(listener))
-        // Pausing again shouldn't affect anything. We should still only get one callback.
-        pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(listener))
-        // Similarly, adding the listener again shouldn't affect anything, as this does not resume the listening of the listener.
-        addListener(listener, toConsistencyManager: consistencyManager)
-
-        testModel = listener.model as! TestModel
-        let updateModel1 = TestModel(id: "2", data: -2, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let updateModel2 = TestModel(id: "4", data: -4, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let batchModel = BatchUpdateModel(models: [updateModel1, updateModel2])
-        updateWithNewModel(batchModel, consistencyManager: consistencyManager, context: "change")
-
-        testModel = listener.model as! TestModel
-        // Updates have happened, but we didn't listen for them.
-        XCTAssertEqual(testModel.children[0].data, 2)
-        XCTAssertEqual(testModel.children[1].data, 4)
-        XCTAssertEqual(modelUpdates.changedModelIds, [])
-        XCTAssertEqual(modelUpdates.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates, 0)
-
-        let updateModel3 = TestModel(id: "2", data: -5, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let updateModel4 = TestModel(id: "4", data: -6, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let batchModel2 = BatchUpdateModel(models: [updateModel3, updateModel4])
-        updateWithNewModel(batchModel2, consistencyManager: consistencyManager, context: "change2")
-
-        testModel = listener.model as! TestModel
-        // Updates have happened, but we didn't listen for them.
-        XCTAssertEqual(testModel.children[0].data, 2)
-        XCTAssertEqual(testModel.children[1].data, 4)
-        XCTAssertEqual(modelUpdates.changedModelIds, [])
-        XCTAssertEqual(modelUpdates.deletedModelIds, [])
-        XCTAssertNil(contextString)
-        XCTAssertEqual(numberOfUpdates, 0)
-
-        // Resume listening for changes, and get all previous changes.
-        resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
-
-        // Both models were updated, and now we have listened to those updates.
-        testModel = listener.model as! TestModel
-        XCTAssertEqual(testModel.children[0].data, -5)
-        XCTAssertEqual(testModel.children[1].data, -6)
-        XCTAssertEqual(modelUpdates.changedModelIds, ["0","2","4"]) // O is the root, so it's changed as well
-        XCTAssertEqual(modelUpdates.deletedModelIds, [])
-        XCTAssertEqual(contextString, "change2") // Only the last context is received.
-        XCTAssertEqual(numberOfUpdates, 1) // We only count the final batch update to the models that occurs after we resume listening.
     }
 
     /**
@@ -123,88 +125,90 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      We keep track of the number of updates (delegate method callbacks) for each listener.
      */
     func testMultipleListenersWithPausingAndResuming() {
-        var (listeners, consistencyManager) = setUpListeners(2)
-        let activeListener = listeners[0]
-        let pausedListener = listeners[1]
+        for testProjections in [true, false] {
+            var (listeners, consistencyManager) = setUpListeners(2, testProjections: testProjections)
+            let activeListener = listeners[0]
+            let pausedListener = listeners[1]
 
-        var numberOfUpdates1 = 0
-        var numberOfUpdates2 = 0
-        var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
-        activeListener.updateClosure = { (_, updates) in
-            numberOfUpdates1 += 1
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
+            var numberOfUpdates1 = 0
+            var numberOfUpdates2 = 0
+            var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
+            activeListener.updateClosure = { (_, updates) in
+                numberOfUpdates1 += 1
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+            pausedListener.updateClosure = { (_, updates) in
+                numberOfUpdates2 += 1
+                modelUpdatesPausedListener = updates
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+
+            // Current models before the update
+            for listener in [activeListener, pausedListener] {
+                let testModel = testModelFromListenerModel(listener.model)!
+                XCTAssertEqual(testModel.children[0].data, 2)
+                XCTAssertEqual(testModel.children[1].data, 4)
+                XCTAssertEqual(numberOfUpdates1, 0)
+            }
+
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+            pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(pausedListener))
+
+            let updateModel1a = TestModel(id: "2", data: -22, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let updateModel2a = TestModel(id: "4", data: -44, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let batchModel1 = BatchUpdateModel(models: [updateModel1a, updateModel2a])
+
+            updateWithNewModel(batchModel1, consistencyManager: consistencyManager)
+
+            let updateModel1b = TestModel(id: "2", data: -2, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let updateModel2b = TestModel(id: "4", data: -4, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let batchModel2 = BatchUpdateModel(models: [updateModel1b, updateModel2b])
+            // Updating the models
+            updateWithNewModel(batchModel2, consistencyManager: consistencyManager)
+
+            // After the first two updates
+            var testModel1 = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel1.children[0].data, -2)
+            XCTAssertEqual(testModel1.children[1].data, -4)
+            XCTAssertEqual(numberOfUpdates1, 2)
+
+            var testModel2 = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel2.children[0].data, 2)
+            XCTAssertEqual(testModel2.children[1].data, 4)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates2, 0)
+
+            // Resume listening for changes, and get all previous changes in a batch update
+            resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+
+            testModel2 = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel2.children[0].data, -2)
+            XCTAssertEqual(testModel2.children[1].data, -4)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, ["0","2","4"])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates2, 1)
+
+            let updateModel3 = TestModel(id: "2", data: -5, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let updateModel4 = TestModel(id: "4", data: -6, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
+            let batchModel3 = BatchUpdateModel(models: [updateModel3, updateModel4])
+            updateWithNewModel(batchModel3, consistencyManager: consistencyManager)
+
+            testModel1 = testModelFromListenerModel(activeListener.model)!
+            testModel2 = testModelFromListenerModel(pausedListener.model)!
+
+            // After the third update
+            XCTAssertEqual(testModel1.children[0].data, -5)
+            XCTAssertEqual(testModel1.children[1].data, -6)
+            XCTAssertEqual(numberOfUpdates1, 3)
+            XCTAssertEqual(testModel2.children[0].data, -5)
+            XCTAssertEqual(testModel2.children[1].data, -6)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, ["0","2","4"])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates2, 2)
         }
-        pausedListener.updateClosure = { (_, updates) in
-            numberOfUpdates2 += 1
-            modelUpdatesPausedListener = updates
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
-        }
-
-        // Current models before the update
-        for listener in [activeListener, pausedListener] {
-            let testModel = listener.model as! TestModel
-            XCTAssertEqual(testModel.children[0].data, 2)
-            XCTAssertEqual(testModel.children[1].data, 4)
-            XCTAssertEqual(numberOfUpdates1, 0)
-        }
-
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-        pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(pausedListener))
-
-        let updateModel1a = TestModel(id: "2", data: -22, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let updateModel2a = TestModel(id: "4", data: -44, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let batchModel1 = BatchUpdateModel(models: [updateModel1a, updateModel2a])
-
-        updateWithNewModel(batchModel1, consistencyManager: consistencyManager)
-
-        let updateModel1b = TestModel(id: "2", data: -2, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let updateModel2b = TestModel(id: "4", data: -4, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let batchModel2 = BatchUpdateModel(models: [updateModel1b, updateModel2b])
-        // Updating the models
-        updateWithNewModel(batchModel2, consistencyManager: consistencyManager)
-
-        // After the first two updates
-        var testModel1 = activeListener.model as! TestModel
-        XCTAssertEqual(testModel1.children[0].data, -2)
-        XCTAssertEqual(testModel1.children[1].data, -4)
-        XCTAssertEqual(numberOfUpdates1, 2)
-
-        var testModel2 = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel2.children[0].data, 2)
-        XCTAssertEqual(testModel2.children[1].data, 4)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates2, 0)
-
-        // Resume listening for changes, and get all previous changes in a batch update
-        resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-
-        testModel2 = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel2.children[0].data, -2)
-        XCTAssertEqual(testModel2.children[1].data, -4)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, ["0","2","4"])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates2, 1)
-
-        let updateModel3 = TestModel(id: "2", data: -5, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let updateModel4 = TestModel(id: "4", data: -6, children: [], requiredModel: TestRequiredModel(id: "21", data: -1))
-        let batchModel3 = BatchUpdateModel(models: [updateModel3, updateModel4])
-        updateWithNewModel(batchModel3, consistencyManager: consistencyManager)
-
-        testModel1 = activeListener.model as! TestModel
-        testModel2 = pausedListener.model as! TestModel
-
-        // After the third update
-        XCTAssertEqual(testModel1.children[0].data, -5)
-        XCTAssertEqual(testModel1.children[1].data, -6)
-        XCTAssertEqual(numberOfUpdates1, 3)
-        XCTAssertEqual(testModel2.children[0].data, -5)
-        XCTAssertEqual(testModel2.children[1].data, -6)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, ["0","2","4"])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates2, 2)
     }
 
     /**
@@ -212,34 +216,36 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      There should not be any updates to pick up.
      */
     func testNoChangesWhilePaused() {
-        let (listeners, consistencyManager) = setUpListeners(1)
-        let listener = listeners[0]
+        for testProjections in [true, false] {
+            let (listeners, consistencyManager) = setUpListeners(1, testProjections: testProjections)
+            let listener = listeners[0]
 
-        var numberOfUpdates = 0
-        var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
-        listener.updateClosure = { (_, updates) in
-            numberOfUpdates += 1
-            modelUpdates = updates
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
+            var numberOfUpdates = 0
+            var modelUpdates = ModelUpdates(changedModelIds: [], deletedModelIds: [])
+            listener.updateClosure = { (_, updates) in
+                numberOfUpdates += 1
+                modelUpdates = updates
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+
+            // Current model before the update
+            var testModel = testModelFromListenerModel(listener.model)!
+            XCTAssertEqual(testModel.children[0].data, 2)
+            XCTAssertEqual(numberOfUpdates, 0)
+
+            XCTAssertFalse(consistencyManager.isPaused(listener))
+            pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(listener))
+            resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(listener))
+
+            // Current models before the update
+            testModel = testModelFromListenerModel(listener.model)!
+            XCTAssertEqual(testModel.children[0].data, 2)
+            XCTAssertEqual(modelUpdates.changedModelIds, [])
+            XCTAssertEqual(modelUpdates.deletedModelIds, [])
+            XCTAssertEqual(numberOfUpdates, 0)
         }
-
-        // Current model before the update
-        var testModel = listener.model as! TestModel
-        XCTAssertEqual(testModel.children[0].data, 2)
-        XCTAssertEqual(numberOfUpdates, 0)
-
-        XCTAssertFalse(consistencyManager.isPaused(listener))
-        pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(listener))
-        resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(listener))
-
-        // Current models before the update
-        testModel = listener.model as! TestModel
-        XCTAssertEqual(testModel.children[0].data, 2)
-        XCTAssertEqual(modelUpdates.changedModelIds, [])
-        XCTAssertEqual(modelUpdates.deletedModelIds, [])
-        XCTAssertEqual(numberOfUpdates, 0)
     }
 
     /**
@@ -296,106 +302,110 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      Also, we ensure that the changelist is left as empty when the paused listener resumes listening.
      */
     func testChangesThatCancelOut() {
-        var testModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
-        let consistencyManager = ConsistencyManager()
-        let pausedListener = TestListener(model: testModel)
-        let activeListener = TestListener(model: testModel)
-        addListener(pausedListener, toConsistencyManager: consistencyManager)
-        addListener(activeListener, toConsistencyManager: consistencyManager)
-
-        var numberOfUpdatesToPausedListener = 0
-        var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
-        pausedListener.updateClosure = { (_, updates) in
-            numberOfUpdatesToPausedListener += 1
-            modelUpdatesPausedListener = updates
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
-        }
-        var contextStringSavedToPausedListener: String?
-        pausedListener.contextClosure = { context in
-            if let context = context as? String {
-                contextStringSavedToPausedListener = context
+        for testProjections in [true, false] {
+            let model = TestModelGenerator.consistencyManagerModelWithTotalChildren(2, branchingFactor: 0, projectionModel: testProjections) { _ in
+                return true
             }
-        }
-        var numberOfUpdatesToActiveListener = 0
-        var modelUpdatesActiveListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
-        activeListener.updateClosure = { (_, updates) in
-            numberOfUpdatesToActiveListener += 1
-            modelUpdatesActiveListener = updates
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
-        }
-        var contextStringSavedToActiveListener: String?
-        activeListener.contextClosure = { context in
-            if let context = context as? String {
-                contextStringSavedToActiveListener = context
+            let consistencyManager = ConsistencyManager()
+            let pausedListener = TestListener(model: model)
+            let activeListener = TestListener(model: model)
+            addListener(pausedListener, toConsistencyManager: consistencyManager)
+            addListener(activeListener, toConsistencyManager: consistencyManager)
+
+            var numberOfUpdatesToPausedListener = 0
+            var modelUpdatesPausedListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
+            pausedListener.updateClosure = { (_, updates) in
+                numberOfUpdatesToPausedListener += 1
+                modelUpdatesPausedListener = updates
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
             }
+            var contextStringSavedToPausedListener: String?
+            pausedListener.contextClosure = { context in
+                if let context = context as? String {
+                    contextStringSavedToPausedListener = context
+                }
+            }
+            var numberOfUpdatesToActiveListener = 0
+            var modelUpdatesActiveListener = ModelUpdates(changedModelIds: [], deletedModelIds: [])
+            activeListener.updateClosure = { (_, updates) in
+                numberOfUpdatesToActiveListener += 1
+                modelUpdatesActiveListener = updates
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+            var contextStringSavedToActiveListener: String?
+            activeListener.contextClosure = { context in
+                if let context = context as? String {
+                    contextStringSavedToActiveListener = context
+                }
+            }
+
+            // Current model before the update
+            var testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
+            testModel = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToActiveListener, 0)
+
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+            pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(pausedListener))
+
+            let updateModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: -5))
+            updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "firstChange")
+
+            // Update has happened, but we didn't listen for it on the first listener.
+            testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertNil(contextStringSavedToPausedListener)
+            // We listened on the second listener.
+            testModel = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, -5)
+            XCTAssertEqual(numberOfUpdatesToActiveListener, 1)
+            XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
+            XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
+            XCTAssertEqual(contextStringSavedToActiveListener!, "firstChange")
+
+            let undoUpdateModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
+            updateWithNewModel(undoUpdateModel, consistencyManager: consistencyManager, context: "undoingChange")
+
+            // Update has happened, but we didn't listen for it on the first listener.
+            testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertNil(contextStringSavedToPausedListener)
+            // We listened on the second listener.
+            testModel = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToActiveListener, 2)
+            XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
+            XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
+            XCTAssertEqual(contextStringSavedToActiveListener!, "undoingChange")
+
+            // Resume listening for changes, and get all previous changes
+            resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+
+            // Make sure that we received no updates on the paused listener.
+            testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
+            XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
+            XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
+            XCTAssertNil(contextStringSavedToPausedListener)
+
+            testModel = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertEqual(numberOfUpdatesToActiveListener, 2)
+            XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
+            XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
+            XCTAssertEqual(contextStringSavedToActiveListener!, "undoingChange")
         }
-
-        // Current model before the update
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
-        testModel = activeListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToActiveListener, 0)
-
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-        pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(pausedListener))
-
-        let updateModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: -5))
-        updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "firstChange")
-
-        // Update has happened, but we didn't listen for it on the first listener.
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertNil(contextStringSavedToPausedListener)
-        // We listened on the second listener.
-        testModel = activeListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, -5)
-        XCTAssertEqual(numberOfUpdatesToActiveListener, 1)
-        XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
-        XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
-        XCTAssertEqual(contextStringSavedToActiveListener!, "firstChange")
-
-        let undoUpdateModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
-        updateWithNewModel(undoUpdateModel, consistencyManager: consistencyManager, context: "undoingChange")
-
-        // Update has happened, but we didn't listen for it on the first listener.
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertNil(contextStringSavedToPausedListener)
-        // We listened on the second listener.
-        testModel = activeListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToActiveListener, 2)
-        XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
-        XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
-        XCTAssertEqual(contextStringSavedToActiveListener!, "undoingChange")
-
-        // Resume listening for changes, and get all previous changes
-        resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-
-        // Make sure that we received no updates on the paused listener.
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToPausedListener, 0)
-        XCTAssertEqual(modelUpdatesPausedListener.changedModelIds, [])
-        XCTAssertEqual(modelUpdatesPausedListener.deletedModelIds, [])
-        XCTAssertNil(contextStringSavedToPausedListener)
-
-        testModel = activeListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertEqual(numberOfUpdatesToActiveListener, 2)
-        XCTAssertEqual(modelUpdatesActiveListener.changedModelIds, ["0","1"])
-        XCTAssertEqual(modelUpdatesActiveListener.deletedModelIds, [])
-        XCTAssertEqual(contextStringSavedToActiveListener!, "undoingChange")
     }
 
     /**
@@ -405,10 +415,10 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      We confirm at the end that only the persistent deletes and changes stay in the changelist when the listener
      resumes listening.
 
-          0
-        / | \
-       2  4  1r
-      /
+     0
+     / | \
+     2  4  1r
+     /
      3r
 
      Pause
@@ -424,10 +434,10 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      Resume
      Result should be: Deleted [], and Updated [0,2]
 
-          0
-        / | \
-       2' 4  1r
-      /
+     0
+     / | \
+     2' 4  1r
+     /
      3r
      */
     func testSomeChangesThatCancelOut() {
@@ -476,56 +486,60 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      After resuming, it picks up the change accordingly.
      */
     func testDeleteDuringPausedState() {
-        var testModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
-        let consistencyManager = ConsistencyManager()
-        let pausedListener = TestListener(model: testModel)
-        let activeListener = TestListener(model: testModel)
-        addListener(pausedListener, toConsistencyManager: consistencyManager)
-        addListener(activeListener, toConsistencyManager: consistencyManager)
+        for testProjections in [true, false] {
+            let model = TestModelGenerator.consistencyManagerModelWithTotalChildren(2, branchingFactor: 0, projectionModel: testProjections) { _ in
+                return true
+            }
+            let consistencyManager = ConsistencyManager()
+            let pausedListener = TestListener(model: model)
+            let activeListener = TestListener(model: model)
+            addListener(pausedListener, toConsistencyManager: consistencyManager)
+            addListener(activeListener, toConsistencyManager: consistencyManager)
 
-        var calledPausedListenerUpdateClosure = false
-        var numberOfUpdatesforPausedListener = 0
-        pausedListener.updateClosure = { model, updates in
-            calledPausedListenerUpdateClosure = true
-            XCTAssertEqual(updates.changedModelIds.count, 0)
-            XCTAssertEqual(updates.deletedModelIds, ["0"])
-            numberOfUpdatesforPausedListener += 1
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
+            var calledPausedListenerUpdateClosure = false
+            var numberOfUpdatesforPausedListener = 0
+            pausedListener.updateClosure = { _, updates in
+                calledPausedListenerUpdateClosure = true
+                XCTAssertEqual(updates.changedModelIds.count, 0)
+                XCTAssertEqual(updates.deletedModelIds, ["0"])
+                numberOfUpdatesforPausedListener += 1
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+            var calledActiveListenerUpdateClosure = false
+            var numberOfUpdatesForActiveListener = 0
+            activeListener.updateClosure = { model, updates in
+                calledActiveListenerUpdateClosure = true
+                numberOfUpdatesForActiveListener += 1
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+
+            // Current model before the delete
+            var testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            testModel = testModelFromListenerModel(activeListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+            pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(pausedListener))
+            updateWithNewModel(TestModel(id: "0", data: 1, children: [], requiredModel: TestRequiredModel(id: "1", data: 0)), consistencyManager: consistencyManager)
+            deleteModel(testModel, consistencyManager: consistencyManager)
+
+            // Delete has happened, but we didn't listen for it on the first listener.
+            testModel = testModelFromListenerModel(pausedListener.model)!
+            XCTAssertEqual(testModel.requiredModel.data, 0)
+            XCTAssertFalse(calledPausedListenerUpdateClosure)
+            // The second listener got the change.
+            XCTAssertTrue(calledActiveListenerUpdateClosure)
+
+            // Resume listening for changes, and get all previous changes.
+            resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(pausedListener))
+            XCTAssertTrue(calledPausedListenerUpdateClosure)
+            XCTAssertTrue(calledActiveListenerUpdateClosure)
+            XCTAssertEqual(numberOfUpdatesforPausedListener, 1)
+            XCTAssertEqual(numberOfUpdatesForActiveListener, 2)
         }
-        var calledActiveListenerUpdateClosure = false
-        var numberOfUpdatesForActiveListener = 0
-        activeListener.updateClosure = { model, updates in
-            calledActiveListenerUpdateClosure = true
-            numberOfUpdatesForActiveListener += 1
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
-        }
-
-        // Current model before the delete
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        testModel = activeListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-        pauseListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(pausedListener))
-        updateWithNewModel(TestModel(id: "0", data: 1, children: [], requiredModel: TestRequiredModel(id: "1", data: 0)), consistencyManager: consistencyManager)
-        deleteModel(testModel, consistencyManager: consistencyManager)
-
-        // Delete has happened, but we didn't listen for it on the first listener.
-        testModel = pausedListener.model as! TestModel
-        XCTAssertEqual(testModel.requiredModel.data, 0)
-        XCTAssertFalse(calledPausedListenerUpdateClosure)
-        // The second listener got the change.
-        XCTAssertTrue(calledActiveListenerUpdateClosure)
-
-        // Resume listening for changes, and get all previous changes.
-        resumeListeningForUpdates(pausedListener, consistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(pausedListener))
-        XCTAssertTrue(calledPausedListenerUpdateClosure)
-        XCTAssertTrue(calledActiveListenerUpdateClosure)
-        XCTAssertEqual(numberOfUpdatesforPausedListener, 1)
-        XCTAssertEqual(numberOfUpdatesForActiveListener, 2)
     }
 
     /**
@@ -564,37 +578,40 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      If we update a submodel, then delete the whole tree, we shouldn't have anything in the updates.
      */
     func testUpdateThenDeleteWholeModel() {
-        let child = TestModel(id: "2", data: 0, children: [], requiredModel: TestRequiredModel(id: nil, data: 0))
-        let modelToDelete = TestRequiredModel(id: "1", data: 0)
-        let model = TestModel(id: "0", data: nil, children: [child], requiredModel: modelToDelete)
+        for testProjections in [true, false] {
+            let modelToDelete = TestRequiredModel(id: "1", data: 0)
+            let model = TestModelGenerator.consistencyManagerModelWithTotalChildren(4, branchingFactor: 1, projectionModel: testProjections) { _ in
+                return true
+            }
 
-        let consistencyManager = ConsistencyManager()
-        let listener = TestListener(model: model)
+            let consistencyManager = ConsistencyManager()
+            let listener = TestListener(model: model)
 
-        var numberOfUpdates = 0
-        listener.updateClosure = { (_, updates) in
-            numberOfUpdates += 1
-            XCTAssertEqual(updates.deletedModelIds, ["0", "1"])
-            XCTAssertEqual(updates.changedModelIds, [])
-            XCTAssertTrue(NSThread.currentThread().isMainThread)
+            var numberOfUpdates = 0
+            listener.updateClosure = { (_, updates) in
+                numberOfUpdates += 1
+                XCTAssertEqual(updates.deletedModelIds, ["0", "1"])
+                XCTAssertEqual(updates.changedModelIds, [])
+                XCTAssertTrue(NSThread.currentThread().isMainThread)
+            }
+
+            addListener(listener, toConsistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(listener))
+            pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertTrue(consistencyManager.isPaused(listener))
+
+            let updateModel = TestModel(id: "2", data: 1, children: [], requiredModel: TestRequiredModel(id: nil, data: 0))
+            updateWithNewModel(updateModel, consistencyManager: consistencyManager)
+            deleteModel(modelToDelete, consistencyManager: consistencyManager)
+
+            XCTAssertEqual(numberOfUpdates, 0)
+
+            resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
+            XCTAssertFalse(consistencyManager.isPaused(listener))
+
+            XCTAssertEqual(numberOfUpdates, 1)
+            XCTAssertTrue(listener.model == nil)
         }
-
-        addListener(listener, toConsistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(listener))
-        pauseListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertTrue(consistencyManager.isPaused(listener))
-
-        let updateModel = TestModel(id: "2", data: 1, children: [], requiredModel: TestRequiredModel(id: nil, data: 0))
-        updateWithNewModel(updateModel, consistencyManager: consistencyManager)
-        deleteModel(modelToDelete, consistencyManager: consistencyManager)
-
-        XCTAssertEqual(numberOfUpdates, 0)
-
-        resumeListeningForUpdates(listener, consistencyManager: consistencyManager)
-        XCTAssertFalse(consistencyManager.isPaused(listener))
-
-        XCTAssertEqual(numberOfUpdates, 1)
-        XCTAssertTrue(listener.model == nil)
     }
 
     /**
@@ -653,13 +670,13 @@ class PauseListenerTests: ConsistencyManagerTestCase {
     func testCleanMemoryForPausedListeners() {
         let model = TestRequiredModel(id: "0", data: 0)
         let consistencyManager = ConsistencyManager()
-        
+
         autoreleasepool {
             let strongListener: TestListener? = TestListener(model: model)
             addListener(strongListener!, toConsistencyManager: consistencyManager)
             pauseListeningForUpdates(strongListener!, consistencyManager: consistencyManager)
             XCTAssertEqual(consistencyManager.pausedListeners.count, 1)
-            
+
         }
 
         XCTAssertEqual(consistencyManager.pausedListeners.count, 1)
@@ -733,36 +750,40 @@ class PauseListenerTests: ConsistencyManagerTestCase {
      a batch listener to a consistency manager that you do not also listen for updates on the child listener.
      */
     func testPausingListenerWithinBatchListener() {
-        let testModel = TestModel(id: "0", data: 0, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
-        let consistencyManager = ConsistencyManager()
-        let individualListener = TestListener(model: testModel)
-        let batchUpdateListener = BatchListener(listeners: [individualListener], consistencyManager: consistencyManager)
-        let batchDelegate = TestBatchListenersDelegate()
-        batchUpdateListener.delegate = batchDelegate
+        for testProjections in [true, false] {
+            let testModel = TestModelGenerator.consistencyManagerModelWithTotalChildren(2, branchingFactor: 0, projectionModel: testProjections) { _ in
+                return true
+            }
+            let consistencyManager = ConsistencyManager()
+            let individualListener = TestListener(model: testModel)
+            let batchUpdateListener = BatchListener(listeners: [individualListener], consistencyManager: consistencyManager)
+            let batchDelegate = TestBatchListenersDelegate()
+            batchUpdateListener.delegate = batchDelegate
 
-        addListener(individualListener, toConsistencyManager: consistencyManager)
-        pauseListeningForUpdates(individualListener, consistencyManager: consistencyManager)
+            addListener(individualListener, toConsistencyManager: consistencyManager)
+            pauseListeningForUpdates(individualListener, consistencyManager: consistencyManager)
 
-        var updatesToBatch = 0
-        batchDelegate.updateClosure = { _, _, _, _ in
-            updatesToBatch += 1
+            var updatesToBatch = 0
+            batchDelegate.updateClosure = { _, _, _, _ in
+                updatesToBatch += 1
+            }
+
+            var updatesToIndividual = 0
+            individualListener.updateClosure = { _, _ in
+                updatesToIndividual += 1
+            }
+
+            let updateModel = TestModel(id: "0", data: 4, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
+            updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "context")
+            XCTAssertEqual(updatesToBatch, 1)
+            XCTAssertEqual(updatesToIndividual, 1)
+
+            resumeListeningForUpdates(individualListener, consistencyManager: consistencyManager)
+            XCTAssertEqual(updatesToBatch, 1)
+            XCTAssertEqual(updatesToIndividual, 1)
         }
-
-        var updatesToIndividual = 0
-        individualListener.updateClosure = { _, _ in
-            updatesToIndividual += 1
-        }
-
-        let updateModel = TestModel(id: "0", data: 4, children: [], requiredModel: TestRequiredModel(id: "1", data: 0))
-        updateWithNewModel(updateModel, consistencyManager: consistencyManager, context: "context")
-        XCTAssertEqual(updatesToBatch, 1)
-        XCTAssertEqual(updatesToIndividual, 1)
-
-        resumeListeningForUpdates(individualListener, consistencyManager: consistencyManager)
-        XCTAssertEqual(updatesToBatch, 1)
-        XCTAssertEqual(updatesToIndividual, 1)
     }
-    
+
     class TestBatchListenersDelegate: BatchListenerDelegate {
 
         var updateClosure: ((BatchListener, [ConsistencyManagerListener], ModelUpdates, Any?)->())?


### PR DESCRIPTION
```
- Added a new model which is a projection of TestModel
- Added a new generator method which returns this
- Added the ability to convert from ProjectionTestModel to TestModel (useful for migrating tests)
- Updated a bunch of test files to do both projection and regular testing. This gives us great test coverage.
```
