### PR TITLE
Adding the ability to clear and cancel all listeners and operations

### DIFF
--- a/ConsistencyManager.xcodeproj/project.pbxproj
+++ b/ConsistencyManager.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		615B9CA91D4FFD430091F71A /* ProjectionTestModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615B9CA81D4FFD430091F71A /* ProjectionTestModel.swift */; };
 		6179D1A61D5133CB00A5209E /* ProjectionTreeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179D1A51D5133CB00A5209E /* ProjectionTreeModel.swift */; };
 		6179D1A81D5137A100A5209E /* ProjectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179D1A71D5137A100A5209E /* ProjectionTests.swift */; };
+		6179D1C81D526C8F00A5209E /* ClearAndCancelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6179D1C71D526C8F00A5209E /* ClearAndCancelTests.swift */; };
 		F29D8FC71CC52EBB005DBB71 /* PauseListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29D8FC61CC52EBB005DBB71 /* PauseListenerTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -99,6 +100,7 @@
 		615B9CA81D4FFD430091F71A /* ProjectionTestModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionTestModel.swift; sourceTree = "<group>"; };
 		6179D1A51D5133CB00A5209E /* ProjectionTreeModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionTreeModel.swift; sourceTree = "<group>"; };
 		6179D1A71D5137A100A5209E /* ProjectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProjectionTests.swift; sourceTree = "<group>"; };
+		6179D1C71D526C8F00A5209E /* ClearAndCancelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClearAndCancelTests.swift; sourceTree = "<group>"; };
 		61DBAA5419FFF64100A23A60 /* ConsistencyManager.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ConsistencyManager.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		61DBAA5F19FFF64100A23A60 /* ConsistencyManagerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ConsistencyManagerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F29D8FC61CC52EBB005DBB71 /* PauseListenerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PauseListenerTests.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				6144A8161CB6DF1B00025127 /* UpdateTests.swift */,
 				6144A8201CB6DF1B00025127 /* ModelUpdatesTests.swift */,
 				6179D1A71D5137A100A5209E /* ProjectionTests.swift */,
+				6179D1C71D526C8F00A5209E /* ClearAndCancelTests.swift */,
 				6144A81F1CB6DF1B00025127 /* Info.plist */,
 			);
 			path = ConsistencyManagerTests;
@@ -384,6 +387,7 @@
 				6144A8221CB6DF1B00025127 /* BatchUpdateTests.swift in Sources */,
 				6144A8241CB6DF1B00025127 /* DeleteTests.swift in Sources */,
 				613704301CCA90D3008D0EBB /* WeakListenerArrayTests.swift in Sources */,
+				6179D1C81D526C8F00A5209E /* ClearAndCancelTests.swift in Sources */,
 				6144A8251CB6DF1B00025127 /* ErrorTests.swift in Sources */,
 				6144A8231CB6DF1B00025127 /* ContextTests.swift in Sources */,
 				6144A8261CB6DF1B00025127 /* ListenerTests.swift in Sources */,

--- a/ConsistencyManager/ConsistencyManager.swift
+++ b/ConsistencyManager/ConsistencyManager.swift
@@ -102,7 +102,7 @@ public class ConsistencyManager {
     /**
      Private queue used for all the real work this library does. It's serial so all the requests to this class are made in order.
      */
-    let dispatchQueue = dispatch_queue_create("com.consistencyManager.internalQueue", DISPATCH_QUEUE_SERIAL)
+    let queue = NSOperationQueue()
 
     /// Small class which listens for memory warnings. When we get a memory warning, we'll purge as much memory as we can.
     private let memoryWarningListener = MemoryWarningListener()
@@ -116,6 +116,11 @@ public class ConsistencyManager {
      Designated initializer.
      */
     public init() {
+        // Make it a serial queue
+        queue.maxConcurrentOperationCount = 1
+        // This seems like a good value for the ConsistencyManager.
+        queue.qualityOfService = .Utility
+        queue.name = "com.consistencyManager.internalQueue"
         memoryWarningListener.delegate = self
         // Doing this in the next tick to give the caller a chance to set garbageCollectionInterval
         dispatch_async(dispatch_get_main_queue()) { 
@@ -150,7 +155,7 @@ public class ConsistencyManager {
      - parameter onModel: the model you want to listen to with this listener
      */
     public func listenForUpdates(listener: ConsistencyManagerListener, onModel model: ConsistencyManagerModel) {
-        dispatch_async(dispatchQueue) {
+        dispatchTask { _ in
             self.addListener(listener, recursivelyToChildModels: model)
         }
     }
@@ -170,7 +175,7 @@ public class ConsistencyManager {
         if let index = self.pausedListeners.indexOf({ listener === $0.listener }) {
             self.pausedListeners.removeAtIndex(index)
         }
-        dispatch_async(dispatchQueue) {
+        dispatchTask { _ in
             for (key, listenerArray) in self.listeners {
                 // Let's map the listener array so that we remove any occurance of the listener
                 var newListeners = listenerArray.map { element in
@@ -242,7 +247,7 @@ public class ConsistencyManager {
             return
         }
 
-        dispatch_async(dispatchQueue) {
+        dispatchTask { _ in
 
             // Here, we are doing three steps to verify model updates.
             // When looking at batch model updates, there may be inconsistencies (such as a model which was both deleted and updated).
@@ -303,10 +308,10 @@ public class ConsistencyManager {
      - parameter context: any context parameter, to be passed on to each listener in the delegate method
     */
     public func updateWithNewModel(model: ConsistencyManagerModel, context: Any? = nil) {
-        dispatch_async(dispatchQueue) {
+        dispatchTask { cancelled in
             let tuple = self.childrenAndListenersForModel(model)
             let optionalModelUpdates = CollectionHelpers.optionalValueDictionaryFromDictionary(tuple.modelUpdates)
-            self.updateListeners(tuple.listeners, withUpdatedModels: optionalModelUpdates, context: context)
+            self.updateListeners(tuple.listeners, withUpdatedModels: optionalModelUpdates, context: context, cancelled: cancelled)
         }
     }
 
@@ -324,7 +329,7 @@ public class ConsistencyManager {
      - parameter context: anything you want to pass to each associated listener via the delegate method upon update
      */
     public func deleteModel(model: ConsistencyManagerModel, context: Any? = nil) {
-        dispatch_async(dispatchQueue) {
+        dispatchTask { cancelled in
             if let id = model.modelIdentifier {
                 // First, let's get all the listeners that care about this id
                 let listenersArray: [ConsistencyManagerListener] = {
@@ -341,7 +346,7 @@ public class ConsistencyManager {
 
                 // A simple update dictionary. We're just deleting a model with this id. Nothing else.
                 let updatesDictionary: [String: [ConsistencyManagerModel]?] = [ id: nil ]
-                self.updateListeners(listenersArray, withUpdatedModels: updatesDictionary, context: context)
+                self.updateListeners(listenersArray, withUpdatedModels: updatesDictionary, context: context, cancelled: cancelled)
             } else {
                 dispatch_async(dispatch_get_main_queue()) {
                     self.delegate?.consistencyManager(self, failedWithCriticalError: CriticalError.DeleteIDFailure.rawValue)
@@ -353,12 +358,36 @@ public class ConsistencyManager {
     // MARK: Other
 
     /**
+     This function will clear all current listeners and cancel all pending tasks including any updates.
+
+     This is mainly useful things like running tests when you want to ensure a clean state.
+     The recommended way of removing listeners is to call `removeListener` or dealloc the listener.
+     Due to the unpredictability of cancelling operations, it's possible that updates may occur
+     between calling this method and the completion block being called.
+
+     - parameter completion: Since some of the cleanup is asynchronous, this block is called once the cleanup is complete.
+     Called on the main queue.
+     */
+    public func clearListenersAndCancelAllTasks(completion: (()->Void)?) {
+        pausedListeners.removeAll()
+        queue.cancelAllOperations()
+        dispatchTask { _ in
+            self.listeners.removeAll()
+            // Finally, we should actually wait for the main queue to complete (because we dispatch updates there after checking cancellation)
+            // This also allows us to call the completion on the main queue
+            dispatch_async(dispatch_get_main_queue()) {
+                completion?()
+            }
+        }
+    }
+
+    /**
      This will remove any unnecessary memory held by the consistency manager.
      This is called automatically whenever there is a memory warning, so usually you should not need to ever call this method.
      The class also cleans up memory automatically as it is used, so you shouldn't worry about memory usage.
     */
     public func cleanMemory() {
-        dispatch_async(dispatchQueue) {
+        dispatchTask { _ in
             NSNotificationCenter.defaultCenter().postNotificationName(ConsistencyManager.kCleanMemoryAsynchronousWorkStarted, object: self)
             for (key, var listenersArray) in self.listeners {
                 listenersArray.prune()
@@ -385,10 +414,15 @@ public class ConsistencyManager {
         let garbageCollectionInterval = self.garbageCollectionInterval
         // If garbageCollectionInterval is 0, this means it's disabled.
         if garbageCollectionInterval > 0 {
+            // We're going to use a low priority queue for this timer
+            // We need to use a dispatch queue because NSOperationQueue doesn't support delays
+            let dispatchQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0)
             // Weak here is necessary, otherwise, we'd have a retain cycle.
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(UInt64(garbageCollectionInterval) * NSEC_PER_SEC)), dispatchQueue) { [weak self] in
+                // Don't need to dispatch here. We'll dispatch in cleanMemory. We never want this to be cancelled.
                 self?.cleanMemory()
                 dispatch_async(dispatch_get_main_queue()) {
+                    // Should dispatch here because garbageCollectionInterval is not thread-safe
                     self?.startGarbageCollection()
                 }
             }
@@ -533,7 +567,7 @@ public class ConsistencyManager {
      In the case of this listener being in a paused state, the function updates
      the listener's PausedListener struct accordingly, without notifying the delegate.
      */
-    private func updateListeners(listeners: [ConsistencyManagerListener], withUpdatedModels updatedModels: [String: [ConsistencyManagerModel]?], context: Any?) {
+    private func updateListeners(listeners: [ConsistencyManagerListener], withUpdatedModels updatedModels: [String: [ConsistencyManagerModel]?], context: Any?, cancelled: ()->Bool) {
 
         var currentModels: [(listener: ConsistencyManagerListener, currentModel: ConsistencyManagerModel?)] = []
 
@@ -569,6 +603,11 @@ public class ConsistencyManager {
             }
         }
 
+        if cancelled() {
+            // Let's cancel this operation.
+            return
+        }
+
         // Again, we're just going to use one dispatch_async.
         // In this block, we're going to return the results to the listener or update our paused listeners.
         dispatch_async(dispatch_get_main_queue()) {
@@ -594,6 +633,8 @@ public class ConsistencyManager {
             }
         }
     }
+
+    // MARK: Model Changes
 
     /**
      This function uses the map functionality of the models to generate a new model given a list of modelUpdates.
@@ -694,6 +735,28 @@ public class ConsistencyManager {
         return updates.reduce(model) { current, modelToMerge in
             return current.mergeModel(modelToMerge)
         }
+    }
+
+    // MARK: Threading
+
+    /**
+     A helper function which wraps our queue.
+     You can call the closure provided by the block to check if the operation has been cancelled.
+     */
+    private func dispatchTask(task: (()->Bool)->Void) {
+        // In order to get cancelled for an NSBlockOperation, you need to do a weak dance
+        // If this is strong, then the block will hold a reference to itself and cause a retain cycle
+        weak var weakOperation: NSBlockOperation?
+        let operation = NSBlockOperation() {
+            // Create a function which returns true if the block has been cancelled
+            let cancelled = {
+                // Default to true if weakOperation is nil
+                return weakOperation?.cancelled ?? true
+            }
+            task(cancelled)
+        }
+        weakOperation = operation
+        queue.addOperation(operation)
     }
 
     // MARK: - Memory Warnings

--- a/ConsistencyManagerTests/ClearAndCancelTests.swift
+++ b/ConsistencyManagerTests/ClearAndCancelTests.swift
@@ -1,0 +1,99 @@
+// © 2016 LinkedIn Corp. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+import XCTest
+@testable import ConsistencyManager
+
+class ClearAndCancelTests: ConsistencyManagerTestCase {
+    
+    func testListenerClear() {
+        let testModel = TestRequiredModel(id: "0", data: 0)
+
+        let consistencyManager = ConsistencyManager()
+        let listener = TestListener(model: testModel)
+        let pausedListener = TestListener(model: testModel)
+
+        addListener(listener, toConsistencyManager: consistencyManager)
+        addListener(pausedListener, toConsistencyManager: consistencyManager)
+        consistencyManager.pauseListeningForUpdates(pausedListener)
+
+        let expectation = expectationWithDescription("Wait for clear to complete")
+        consistencyManager.clearListenersAndCancelAllTasks {
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        XCTAssertEqual(consistencyManager.listeners.count, 0)
+        XCTAssertEqual(consistencyManager.pausedListeners.count, 0)
+    }
+
+    func testUpdateCancel() {
+        let testModel = TestRequiredModel(id: "0", data: 0)
+
+        let consistencyManager = ConsistencyManager()
+        let listener = TestListener(model: testModel)
+
+        addListener(listener, toConsistencyManager: consistencyManager)
+
+        listener.updateClosure = { _, _ in
+            XCTFail()
+        }
+
+        let updateModel = TestRequiredModel(id: "0", data: 1)
+        consistencyManager.updateWithNewModel(updateModel)
+
+        let expectation = expectationWithDescription("Wait for clear to complete")
+        consistencyManager.clearListenersAndCancelAllTasks {
+            expectation.fulfill()
+        }
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        waitOnDispatchQueue(consistencyManager)
+        waitOnMainThread()
+
+        // Test succeeds as long as XCTFail() never gets called.
+    }
+
+    /**
+     This test tries cancelling all the blocks while a task is half way complete.
+     The task should still not go through.
+     */
+    func testUpdateCancelWhileTaskRunning() {
+        let testModel = TestRequiredModel(id: "0", data: 0)
+
+        let consistencyManager = ConsistencyManager()
+        let listener = TestListener(model: testModel)
+
+        addListener(listener, toConsistencyManager: consistencyManager)
+
+        listener.updateClosure = { _, _ in
+            XCTFail()
+        }
+
+        let expectation = expectationWithDescription("Wait for clear to complete")
+        listener.currentModelRequested = {
+            // We're half way through this task. So let's cancel everything!
+            consistencyManager.clearListenersAndCancelAllTasks {
+                expectation.fulfill()
+            }
+        }
+
+        let updateModel = TestRequiredModel(id: "0", data: 1)
+        consistencyManager.updateWithNewModel(updateModel)
+
+        waitForExpectationsWithTimeout(10, handler: nil)
+
+        waitOnDispatchQueue(consistencyManager)
+        waitOnMainThread()
+
+        // Test succeeds as long as XCTFail() never gets called.
+    }
+}

--- a/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
+++ b/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
@@ -79,12 +79,13 @@ class ConsistencyManagerTestCase: XCTestCase {
         waitOnMainThread()
     }
 
-    func waitOnDispatchQueue(consistencyManager: ConsistencyManager, timeout: NSTimeInterval = 1) {
+    func waitOnDispatchQueue(consistencyManager: ConsistencyManager, timeout: NSTimeInterval = 10) {
         let expectation = expectationWithDescription("Wait for consistency manager to update internal state")
 
-        dispatch_async(consistencyManager.dispatchQueue) {
+        let operation = NSBlockOperation() {
             expectation.fulfill()
         }
+        consistencyManager.queue.addOperation(operation)
 
         waitForExpectationsWithTimeout(timeout) { error in
             XCTAssertNil(error)

--- a/ConsistencyManagerTests/UpdateOrderingTests.swift
+++ b/ConsistencyManagerTests/UpdateOrderingTests.swift
@@ -65,9 +65,10 @@ class UpdateOrderingTests: ConsistencyManagerTestCase {
                     // First we need to wait for the consistency manager to finish on its queue
                     let expectation = expectationWithDescription("Wait for consistency manager to finish it's task and async to the main queue")
 
-                    dispatch_async(consistencyManager.dispatchQueue) {
+                    let operation = NSBlockOperation() {
                         expectation.fulfill()
                     }
+                    consistencyManager.queue.addOperation(operation)
 
                     waitForExpectationsWithTimeout(10) { error in
                         XCTAssertNil(error)


### PR DESCRIPTION
This is useful when writing tests against the consistency manager and want to ensure no tasks leak into the next test
Added unit tests for the new feature
