### PR TITLE
Quick fix for a flaky test

### DIFF
--- a/ConsistencyManagerTests/ClearAndCancelTests.swift
+++ b/ConsistencyManagerTests/ClearAndCancelTests.swift
@@ -57,7 +57,7 @@ class ClearAndCancelTests: ConsistencyManagerTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
 
         waitOnDispatchQueue(consistencyManager)
-        waitOnMainThread()
+        flushMainQueueOperations()
 
         // Test succeeds as long as XCTFail() never gets called.
     }
@@ -92,7 +92,7 @@ class ClearAndCancelTests: ConsistencyManagerTestCase {
         waitForExpectationsWithTimeout(10, handler: nil)
 
         waitOnDispatchQueue(consistencyManager)
-        waitOnMainThread()
+        flushMainQueueOperations()
 
         // Test succeeds as long as XCTFail() never gets called.
     }

--- a/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
+++ b/ConsistencyManagerTests/HelperClasses/ConsistencyManagerTestCase.swift
@@ -35,7 +35,7 @@ class ConsistencyManagerTestCase: XCTestCase {
         waitOnDispatchQueue(consistencyManager)
 
         // Now, we need to wait for the main queue to do the actual updates
-        waitOnMainThread()
+        flushMainQueueOperations()
     }
 
     /**
@@ -61,7 +61,7 @@ class ConsistencyManagerTestCase: XCTestCase {
         waitOnDispatchQueue(consistencyManager)
 
         // Now, we need to wait for the main queue to do the actual updates
-        waitOnMainThread()
+        flushMainQueueOperations()
     }
 
     func pauseListeningForUpdates(listener: ConsistencyManagerListener, consistencyManager: ConsistencyManager) {
@@ -76,7 +76,7 @@ class ConsistencyManagerTestCase: XCTestCase {
         waitOnDispatchQueue(consistencyManager)
 
         // Now, we need to wait for the main queue to do the actual updates
-        waitOnMainThread()
+        flushMainQueueOperations()
     }
 
     func waitOnDispatchQueue(consistencyManager: ConsistencyManager) {
@@ -92,7 +92,7 @@ class ConsistencyManagerTestCase: XCTestCase {
         }
     }
 
-    func waitOnMainThread() {
+    func flushMainQueueOperations() {
         let expectation = expectationWithDescription("Wait for main queue to finish so the updates have happened")
 
         dispatch_async(dispatch_get_main_queue()) {

--- a/ConsistencyManagerTests/ListenerTests.swift
+++ b/ConsistencyManagerTests/ListenerTests.swift
@@ -105,6 +105,7 @@ class ListenerTests: ConsistencyManagerTestCase {
                     listener = strongListener
 
                     addListener(strongListener, toConsistencyManager: consistencyManager)
+                    waitOnMainThread()
                 }
 
                 XCTAssertNil(listener)

--- a/ConsistencyManagerTests/ListenerTests.swift
+++ b/ConsistencyManagerTests/ListenerTests.swift
@@ -105,7 +105,7 @@ class ListenerTests: ConsistencyManagerTestCase {
                     listener = strongListener
 
                     addListener(strongListener, toConsistencyManager: consistencyManager)
-                    waitOnMainThread()
+                    flushMainQueueOperations()
                 }
 
                 XCTAssertNil(listener)

--- a/ConsistencyManagerTests/MemoryWarningTests.swift
+++ b/ConsistencyManagerTests/MemoryWarningTests.swift
@@ -20,14 +20,6 @@ class MemoryWarningTests: ConsistencyManagerTestCase {
     func testMemoryWarning() {
         let testStart = NSDate()
 
-        NSNotificationCenter.defaultCenter().addObserverForName(ConsistencyManager.kCleanMemoryAsynchronousWorkStarted, object: nil, queue: nil) { _ in
-            self.cleanMemoryStartedTimes.append(NSDate())
-        }
-
-        NSNotificationCenter.defaultCenter().addObserverForName(ConsistencyManager.kCleanMemoryAsynchronousWorkFinished, object: nil, queue: nil) { _ in
-            self.cleanMemoryFinishedTimes.append(NSDate())
-        }
-
         let model = TestRequiredModel(id: "0", data: 0)
 
         // Setting this up with a block ensures that the listener will be released and is out of scope.
@@ -39,6 +31,14 @@ class MemoryWarningTests: ConsistencyManagerTestCase {
 
             return consistencyManager
             }()
+
+        NSNotificationCenter.defaultCenter().addObserverForName(ConsistencyManager.kCleanMemoryAsynchronousWorkStarted, object: consistencyManager, queue: nil) { _ in
+            self.cleanMemoryStartedTimes.append(NSDate())
+        }
+
+        NSNotificationCenter.defaultCenter().addObserverForName(ConsistencyManager.kCleanMemoryAsynchronousWorkFinished, object: consistencyManager, queue: nil) { _ in
+            self.cleanMemoryFinishedTimes.append(NSDate())
+        }
 
         // This part MAY fail in the future if we change the logic for when we prune the listeners dictionary
         // If this starts to fail, we should write this test to prove that memory warnings are doing something


### PR DESCRIPTION
Making sure we're only listening to one consistency manager

Change - now registering for notifications on the consistency manager, not nil.
