### PR TITLE
removes hard-coded local file path for profiling

### DIFF
--- a/ConsistencyManager.xcodeproj/xcshareddata/xcschemes/ConsistencyManager.xcscheme
+++ b/ConsistencyManager.xcodeproj/xcshareddata/xcschemes/ConsistencyManager.xcscheme
@@ -93,12 +93,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      debugDocumentVersioning = "YES"
-      launchAutomaticallySubstyle = "2">
-      <PathRunnable
-         runnableDebuggingMode = "0"
-         FilePath = "/Users/plivesey/Library/Developer/Xcode/DerivedData/ConsistencyManager-ezmcupkggqbxrkawtipbzcwqqolg/Build/Products/ConsistencyManager">
-      </PathRunnable>
+      debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"


### PR DESCRIPTION
this should remove a warning we always see when building ConsistencyManager-iOS through carthage:

`Details:  Unable to find platform for /Users/plivesey/Library/Developer/Xcode/DerivedData/ConsistencyManager-ezmcupkggqbxrkawtipbzcwqqolg/Build/Products/ConsistencyManager: Error Domain=DVTFoundationNSBundleAdditionsErrorDomain Code=1 "Couldn't find platform in Info.plist CFBundleSupportedPlatforms or binary for ConsistencyManager" UserInfo={NSLocalizedDescription=Couldn't find platform in Info.plist CFBundleSupportedPlatforms or binary for ConsistencyManager}`
